### PR TITLE
Implement context aware rate limiter middleware

### DIFF
--- a/ContextAwareRateLimiterMiddleware.cs
+++ b/ContextAwareRateLimiterMiddleware.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace SecureFileSharingAPI
+{
+    /// <summary>
+    /// Middleware that applies a simple in-memory rate limiting strategy.
+    /// It identifies clients by an authorization token if present or by IP address otherwise.
+    /// Requests exceeding the configured limits are rejected with HTTP 429.
+    /// </summary>
+    public class ContextAwareRateLimiterMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<ContextAwareRateLimiterMiddleware> _logger;
+
+        // Stores timestamps of requests per client identifier
+        private static readonly ConcurrentDictionary<string, List<DateTimeOffset>> _requestLog = new();
+
+        // Example rule: allow up to 5 requests per minute per client
+        private static readonly TimeSpan Window = TimeSpan.FromMinutes(1);
+        private const int MaxRequestsPerWindow = 5;
+
+        public ContextAwareRateLimiterMiddleware(RequestDelegate next, ILogger<ContextAwareRateLimiterMiddleware> logger)
+        {
+            _next = next;
+            _logger = logger;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            var identifier = GetClientIdentifier(context);
+            var now = DateTimeOffset.UtcNow;
+
+            var timestamps = _requestLog.GetOrAdd(identifier, _ => new List<DateTimeOffset>());
+
+            lock (timestamps)
+            {
+                // Remove expired timestamps
+                timestamps.RemoveAll(ts => now - ts > Window);
+
+                // Check current request count
+                if (timestamps.Count >= MaxRequestsPerWindow)
+                {
+                    _logger.LogWarning("Rate limit exceeded for {Identifier}", identifier);
+                    context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+                    return;
+                }
+
+                timestamps.Add(now);
+            }
+
+            _logger.LogInformation("Request from {Identifier} allowed", identifier);
+            await _next(context);
+        }
+
+        private static string GetClientIdentifier(HttpContext context)
+        {
+            var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(authHeader))
+            {
+                return $"token:{authHeader}";
+            }
+
+            var ip = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+            return $"ip:{ip}";
+        }
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # SecureFileSharingAPI
+
+This repository demonstrates a simple ASP.NET Core middleware called `ContextAwareRateLimiterMiddleware` used for rate limiting based on client context (IP address or Authorization token). The middleware tracks request timestamps in memory and blocks clients exceeding a fixed limit.
+
+## Middleware Usage
+Add the middleware in your `Startup` or minimal API configuration:
+```csharp
+app.UseMiddleware<ContextAwareRateLimiterMiddleware>();
+```
+
+The middleware will allow up to five requests per minute for each client.
+


### PR DESCRIPTION
## Summary
- add `ContextAwareRateLimiterMiddleware`
- document middleware usage in README

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685cbd3572bc832eb33466c06671916d