### PR TITLE
Add rate limit rule interface and login burst rule

### DIFF
--- a/ClientProfile.cs
+++ b/ClientProfile.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+namespace SecureFileSharingAPI
+{
+    /// <summary>
+    /// Represents a client identified by IP address or token and
+    /// keeps track of recent request timestamps per endpoint.
+    /// </summary>
+    public class ClientProfile
+    {
+        private readonly Dictionary<string, List<DateTimeOffset>> _requestLog = new();
+
+        /// <summary>
+        /// Records a timestamp for the specified endpoint.
+        /// </summary>
+        public void LogRequest(string path, DateTimeOffset timestamp)
+        {
+            if (!_requestLog.TryGetValue(path, out var list))
+            {
+                list = new List<DateTimeOffset>();
+                _requestLog[path] = list;
+            }
+            list.Add(timestamp);
+        }
+
+        /// <summary>
+        /// Gets the recorded timestamps for the specified endpoint.
+        /// </summary>
+        public List<DateTimeOffset> GetRequests(string path)
+        {
+            return _requestLog.TryGetValue(path, out var list) ? list : new List<DateTimeOffset>();
+        }
+    }
+}

--- a/IRateLimitRule.cs
+++ b/IRateLimitRule.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Http;
+
+namespace SecureFileSharingAPI
+{
+    /// <summary>
+    /// Represents a rule that evaluates whether a request should be allowed,
+    /// blocked or logged based on the client's profile and request details.
+    /// </summary>
+    public interface IRateLimitRule
+    {
+        ThrottleDecision Evaluate(ClientProfile profile, HttpRequest request);
+    }
+}

--- a/LoginBurstRule.cs
+++ b/LoginBurstRule.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+
+namespace SecureFileSharingAPI
+{
+    /// <summary>
+    /// Blocks a client if more than a configured number of requests
+    /// are made to the /login endpoint within a short window.
+    /// </summary>
+    public class LoginBurstRule : IRateLimitRule
+    {
+        private readonly TimeSpan _window = TimeSpan.FromSeconds(10);
+        private readonly int _maxRequests;
+
+        public LoginBurstRule(int maxRequests = 5)
+        {
+            _maxRequests = maxRequests;
+        }
+
+        public ThrottleDecision Evaluate(ClientProfile profile, HttpRequest request)
+        {
+            if (!string.Equals(request.Path, "/login", StringComparison.OrdinalIgnoreCase))
+            {
+                return ThrottleDecision.Allow;
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            profile.LogRequest("/login", now);
+            var timestamps = profile.GetRequests("/login");
+
+            // Remove outdated entries
+            timestamps.RemoveAll(ts => now - ts > _window);
+
+            var recentCount = timestamps.Count(ts => now - ts <= _window);
+            if (recentCount > _maxRequests)
+            {
+                return ThrottleDecision.Block;
+            }
+
+            return ThrottleDecision.Allow;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ app.UseMiddleware<ContextAwareRateLimiterMiddleware>();
 
 The middleware will allow up to five requests per minute for each client.
 
+
+## Rate Limit Rules
+
+Custom rules can be implemented using the `IRateLimitRule` interface. The provided `LoginBurstRule`
+blocks clients making more than five requests to the `/login` endpoint within ten seconds.

--- a/ThrottleDecision.cs
+++ b/ThrottleDecision.cs
@@ -1,0 +1,12 @@
+namespace SecureFileSharingAPI
+{
+    /// <summary>
+    /// Possible results of evaluating a rate limit rule.
+    /// </summary>
+    public enum ThrottleDecision
+    {
+        Allow,
+        Block,
+        Log
+    }
+}


### PR DESCRIPTION
## Summary
- add `ThrottleDecision` enum with Allow/Block/Log
- create `ClientProfile` helper for logging request timestamps
- introduce `IRateLimitRule` interface for rule evaluation
- implement `LoginBurstRule` that blocks excessive `/login` requests
- document rate limit rules in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cbdd44e38832e8e2e1b76edaace71