### PR TITLE
Add Swagger and test endpoint

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,12 +1,22 @@
 using Microsoft.EntityFrameworkCore;
 using SecureFileSharingAPI;
+using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlite(builder.Configuration.GetConnectionString("Default") ?? "Data Source=app.db"));
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseMiddleware<ContextAwareRateLimiterMiddleware>();
 
 using (var scope = app.Services.CreateScope())
 {
@@ -15,5 +25,6 @@ using (var scope = app.Services.CreateScope())
 }
 
 app.MapGet("/", () => "Secure File Sharing API");
+app.MapGet("/api/test/ping", () => Results.Ok());
 
 app.Run();

--- a/README.md
+++ b/README.md
@@ -27,3 +27,13 @@ The sample includes an `AppDbContext` configured for SQLite. Run EF Core migrati
  dotnet ef database update
 ```
 The connection string defaults to `Data Source=app.db` and can be overridden in `appsettings.json`.
+
+## Testing Rate Limiting
+
+1. Run the API:
+   ```bash
+   dotnet run
+   ```
+2. Open the Swagger UI at `http://localhost:5000/swagger` to explore endpoints. The sample exposes `/api/test/ping` which simply returns `200 OK`.
+3. Use a tool like Postman to send rapid requests to `/api/test/ping`.
+4. After five requests within a minute, the middleware responds with HTTP `429 Too Many Requests`, demonstrating rate limiting.

--- a/SecureFileSharingAPI.csproj
+++ b/SecureFileSharingAPI.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- upgrade to .NET 8
- enable Swagger UI and rate-limiter middleware
- add `/api/test/ping` endpoint
- document how to test the middleware

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cbf1d71d8832eb2de953633d9626d