### PR TITLE
Add Dockerfile and container usage docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+WORKDIR /app
+COPY --from=build /app/publish .
+ENV ASPNETCORE_URLS=http://+:80
+EXPOSE 80
+ENTRYPOINT ["dotnet", "SecureFileSharingAPI.dll"]

--- a/README.md
+++ b/README.md
@@ -37,3 +37,20 @@ The connection string defaults to `Data Source=app.db` and can be overridden in 
 2. Open the Swagger UI at `http://localhost:5000/swagger` to explore endpoints. The sample exposes `/api/test/ping` which simply returns `200 OK`.
 3. Use a tool like Postman to send rapid requests to `/api/test/ping`.
 4. After five requests within a minute, the middleware responds with HTTP `429 Too Many Requests`, demonstrating rate limiting.
+
+## Docker
+
+Build the Docker image:
+```bash
+docker build -t context-aware-rate-limiter .
+```
+
+Run the container and mount a host directory for the SQLite database:
+```bash
+docker run -p 8080:80 \
+  -v $(pwd)/data:/data \
+  -e ConnectionStrings__Default="Data Source=/data/app.db" \
+  context-aware-rate-limiter
+```
+This publishes the API on `http://localhost:8080` and persists the `app.db` file
+in the `data` folder next to your clone.


### PR DESCRIPTION
## Summary
- build/publish dotnet project in Docker
- document Docker build & run steps in README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1410eb70832e81ee8e471cd28d6c