### PR TITLE
Add rate limiter stats endpoint

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -27,4 +27,37 @@ using (var scope = app.Services.CreateScope())
 app.MapGet("/", () => "Secure File Sharing API");
 app.MapGet("/api/test/ping", () => Results.Ok());
 
+app.MapGet("/api/rate-limiter/stats", async (AppDbContext db) =>
+{
+    var today = DateTime.UtcNow.Date;
+
+    var blockedClientsToday = await db.BlockEvents
+        .CountAsync(b => b.BlockedUntil >= today);
+
+    var mostTriggeredRule = await db.BlockEvents
+        .GroupBy(b => b.RuleTriggered)
+        .OrderByDescending(g => g.Count())
+        .Select(g => g.Key)
+        .FirstOrDefaultAsync();
+
+    var topIps = await db.RequestLogs
+        .Where(r => r.ClientId.StartsWith("ip:"))
+        .GroupBy(r => r.ClientId)
+        .Select(g => new IpActivityDto(
+            g.Key.Substring(3),
+            g.Count()))
+        .OrderByDescending(x => x.RequestCount)
+        .Take(5)
+        .ToListAsync();
+
+    var stats = new RateLimiterStats
+    {
+        BlockedClientsToday = blockedClientsToday,
+        MostTriggeredRule = mostTriggeredRule,
+        TopActiveIps = topIps
+    };
+
+    return Results.Json(stats);
+});
+
 app.Run();

--- a/StatsDto.cs
+++ b/StatsDto.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace SecureFileSharingAPI;
+
+public record IpActivityDto(string Ip, int RequestCount);
+
+public class RateLimiterStats
+{
+    public int BlockedClientsToday { get; set; }
+    public string? MostTriggeredRule { get; set; }
+    public List<IpActivityDto> TopActiveIps { get; set; } = new();
+}


### PR DESCRIPTION
## Summary
- create `RateLimiterStats` and `IpActivityDto` models
- add `/api/rate-limiter/stats` endpoint to return rate limit summary info

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d14e636ac832e9c3b401078794039